### PR TITLE
add tox config and test under py26 and py27

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.pyc
+*.pyo
+.tox
+bin/
+include/
+lib/
+man/

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,9 @@ bin/nosetests: bin/python
 
 bin/coverage: bin/python
 	bin/pip install coverage
+
+bin/tox: bin/python
+	bin/pip install tox
+
+tox: bin/tox
+	bin/tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py26, py27
+
+[testenv]
+commands = nosetests konfig
+deps = nose


### PR DESCRIPTION
As requested in pull request #2.

pypy and py3 test already fail while installing configparser, so I didn't add those. Compatibility with those would be another pull request.
